### PR TITLE
Handle exec() call with options (env, pty = true, etc).

### DIFF
--- a/connectionqueuer.js
+++ b/connectionqueuer.js
@@ -23,8 +23,15 @@ ConnectionQueuer.prototype.start = function () {
           self.stop();
         }
         if (saux !== undefined) {
+
+          var opts = saux.options;
+          if (typeof opts == 'function') {
+            saux.callback = opts;
+            opts = {};
+          }
+
           self.counter--;
-          self.connection.exec(saux.cmd, function (err, stream) {
+          self.connection.exec(saux.cmd, opts, function (err, stream) {
             if (err) {
               self.counter++;
             } else {
@@ -54,8 +61,8 @@ ConnectionQueuer.prototype.stop = function () {
   clearInterval(this.interval);
 };
 
-ConnectionQueuer.prototype.exec = function (cmd, callback) {
-  this.queue.push({'cmd': cmd, 'callback': callback});
+ConnectionQueuer.prototype.exec = function (cmd, opts, callback) {
+  this.queue.push({'cmd': cmd, 'options': opts, 'callback': callback});
 
   if (!this.running) {
     this.start();


### PR DESCRIPTION
I'm currently using the `ssh2` module and I call conn.exec with an options object before the callback. As `ssh2-multiplexer` is, right now, I get this:

```
TypeError: Property 'callback' of object #<Object> is not a function
    at /path/to/node_modules/ssh2-multiplexer/connectionqueuer.js:38:20
    at /path/to/node_modules/ssh2/lib/Channel.js:361:5
    ...
```

This happens because your module assumes the original call is simply `exec(cmd, callback)`. This PR handles the options object and detects whether it was passed or not.
