### PR TITLE
added end() that can cleanly terminate the ssh2 connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssh2-multiplexer",
   "description": "Node.js ssh2 exec multiplexer.",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": "Pedro Dias <petermdias@gmail.com>",
   "maintainers": [
     "apocas <petermdias@gmail.com>"


### PR DESCRIPTION
Current version does not allow user to cleanly terminate ssh2 connection. This adds end() function to ConnectionQueue so that it can terminate the connection, but also send error object (string) to all exec queues so that they won't be waiting for connection indefinitely.

I've also replaced sys (deprecated) with util.